### PR TITLE
Fix “Design in Practice” talk link

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ He also made other not as well known [lisps prior to Clojure](lisps).
 
 ## Talks
 
-* [Design in Practice (Apr 2023)](https://www.youtube.com/watch?v=fTtnx1AAJ-c)
+* [Design in Practice (Apr 2023)](https://www.youtube.com/watch?v=c5QF2HjHLSE)
 * [A History of Clojure (Jun 2021)](https://www.pldi21.org/prerecorded_hopl.11.html)
 * [Maybe Not (Nov 2018)](https://www.youtube.com/watch?v=YR5WdGrpoug)
 * [Datomic Ions (Sep 2018)](https://www.youtube.com/watch?v=thpzXjmYyGk)


### PR DESCRIPTION
Hey there.

I was passing by and clicked on the previous link. YouTube said “This video isn't available anymore”, so I found a copy / reupload or something.

Hope it helps.